### PR TITLE
Fix the Bug with Active Option for `link_to` in `nav`

### DIFF
--- a/lib/bh/helpers/link_to_helper.rb
+++ b/lib/bh/helpers/link_to_helper.rb
@@ -35,6 +35,8 @@ module Bh
     #         end
     #       end
     def link_to(*args, &block)
+      active = args.delete![:active]
+
       link_to = Bh::LinkTo.new self, *args, &block
 
       link_to.append_class! :'alert-link' if Bh::Stack.find(Bh::AlertBox)
@@ -42,8 +44,6 @@ module Bh
       link_to.merge! role: :menuitem if Bh::Stack.find(Bh::Dropdown)
       link_to.merge! tabindex: -1 if Bh::Stack.find(Bh::Dropdown)
       html = super link_to.content, link_to.url, link_to.attributes, &nil
-
-      active = args.extract_options![:active]
 
       if Bh::Stack.find(Bh::Dropdown)
         container = Bh::Base.new(self) { html }

--- a/lib/bh/helpers/link_to_helper.rb
+++ b/lib/bh/helpers/link_to_helper.rb
@@ -35,7 +35,10 @@ module Bh
     #         end
     #       end
     def link_to(*args, &block)
-      active = args.extract_options!.delete![:active]
+      active = args.extract_options![:active]
+
+      # remove the unwanted active option
+      args.extract_options!.except![:active]
 
       link_to = Bh::LinkTo.new self, *args, &block
 

--- a/lib/bh/helpers/link_to_helper.rb
+++ b/lib/bh/helpers/link_to_helper.rb
@@ -35,7 +35,7 @@ module Bh
     #         end
     #       end
     def link_to(*args, &block)
-      active = args.delete![:active]
+      active = args.extract_options!.delete![:active]
 
       link_to = Bh::LinkTo.new self, *args, &block
 


### PR DESCRIPTION
Fixes the small bug related to sending down an unwanted option to the inner `link_to`
